### PR TITLE
Add ds_record to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Available targets:
 
 | Name | Description |
 |------|-------------|
+| <a name="output_ds_record"></a> [ds\_record](#output\_ds\_record) | DS record for zone |
 | <a name="output_key_arn"></a> [key\_arn](#output\_key\_arn) | KMS key arn for Route53 DNSSEC CMK |
 | <a name="output_this_key_arn"></a> [this\_key\_arn](#output\_this\_key\_arn) | Deprecated: KMS key arn for Route53 DNSSEC CMK |
 <!-- markdownlint-restore -->
@@ -287,7 +288,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2021-2022 [UnderGrid Network Services](https://undergrid.net)
+Copyright © 2021-2024 [UnderGrid Network Services](https://undergrid.net)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -59,6 +59,7 @@
 
 | Name | Description |
 |------|-------------|
+| <a name="output_ds_record"></a> [ds\_record](#output\_ds\_record) | DS record for zone |
 | <a name="output_key_arn"></a> [key\_arn](#output\_key\_arn) | KMS key arn for Route53 DNSSEC CMK |
 | <a name="output_this_key_arn"></a> [this\_key\_arn](#output\_this\_key\_arn) | Deprecated: KMS key arn for Route53 DNSSEC CMK |
 <!-- markdownlint-restore -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "key_arn" {
   description = "KMS key arn for Route53 DNSSEC CMK"
   value       = module.kms_key.key_arn
 }
+
+output "ds_record" {
+  description = "DS records for each zone"
+  value       = { for k, v in aws_route53_key_signing_key.this : k => v.ds_record }
+}


### PR DESCRIPTION
## what
* Include DS record for each zone in outputs
* Output will be like this:

	```hcl
	{
	    "ds_record" = {
	      "prod.example.com" = "..."
	    }
	    "key_arn" = "arn:aws:kms:..."
	    "this_key_arn" = "arn:aws:kms:..."
	}
	```

## why
* This was needed by one of our modules to add the DS record for a delegated zone to the primary to create a chain of trust

## references
* None

